### PR TITLE
Add low-rank correlation normalization to CNP

### DIFF
--- a/src/cdnp/model/cnp.py
+++ b/src/cdnp/model/cnp.py
@@ -1,10 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
 import torch
 from diffusers import UNet2DModel
 from torch import nn
 from torch.distributions import Normal
 
 from cdnp.model.ctx import ModelCtx
+from cdnp.model.low_rank_cov import nll as lr_nll
+from cdnp.model.low_rank_cov import unnormalize as lr_unnormalize
 from cdnp.model.util import padded_forward
+
+
+@dataclass
+class CNPPrediction:
+    """Prediction from a CNP model.
+
+    Attributes:
+        mean: Per-pixel mean, shape (B, C, H, W).
+        std: Per-pixel diagonal std, shape (B, C, H, W).
+        V: Low-rank correlation factors, shape (B, rank, C, H, W).
+            None when correlation_rank=0.
+    """
+
+    mean: torch.Tensor
+    std: torch.Tensor
+    V: Optional[torch.Tensor] = None
+
+    @property
+    def stddev(self) -> torch.Tensor:
+        """Alias for std, for backward compatibility with Normal interface."""
+        return self.std
+
+    @property
+    def diagonal_dist(self) -> Normal:
+        """Return a diagonal Normal distribution (ignoring V)."""
+        return Normal(self.mean, self.std)
 
 
 class CNP(nn.Module):
@@ -14,12 +47,14 @@ class CNP(nn.Module):
         device: str,
         min_std: float,
         residual: bool = False,
+        correlation_rank: int = 0,
     ):
         super().__init__()
         self.backbone = backbone
         self.device = device
         self.min_std = min_std
         self.residual = residual
+        self.correlation_rank = correlation_rank
 
     def forward(self, ctx: ModelCtx, trg: torch.Tensor) -> torch.Tensor:
         """
@@ -29,10 +64,10 @@ class CNP(nn.Module):
         :ctx: The context data (e.g., class labels).
         """
 
-        prd_dist = self.predict(ctx)
-        return self.nll(prd_dist, trg)
+        prd = self.predict(ctx)
+        return self.nll(prd, trg)
 
-    def predict(self, ctx: ModelCtx) -> Normal:
+    def predict(self, ctx: ModelCtx) -> CNPPrediction:
         im_ctx = ctx.image_ctx  # (B, C, H, W)
         labels = ctx.label_ctx
 
@@ -44,19 +79,53 @@ class CNP(nn.Module):
 
         pred = padded_forward(self.backbone, im_ctx, timesteps, class_labels=labels)
 
-        mean, std = pred.chunk(2, dim=1)
+        if self.correlation_rank > 0:
+            # Output channels: 2*C (mean + std) + C*rank (low-rank factors)
+            num_out = pred.shape[1]
+            num_trg_channels = num_out // (2 + self.correlation_rank)
+            mean, std_raw, V_raw = pred.split(
+                [num_trg_channels, num_trg_channels, num_trg_channels * self.correlation_rank],
+                dim=1,
+            )
+            # Reshape V from (B, C*rank, H, W) -> (B, rank, C, H, W)
+            B, _, H, W = V_raw.shape
+            V = V_raw.reshape(B, num_trg_channels, self.correlation_rank, H, W)
+            V = V.permute(0, 2, 1, 3, 4)  # (B, rank, C, H, W)
+        else:
+            mean, std_raw = pred.chunk(2, dim=1)
+            V = None
+
         if self.residual:
             num_trg_channels = mean.shape[1]
             # By convention, the last channels of the image context should be the
             # residuals.
             res = im_ctx[:, -num_trg_channels:, :, :]
             mean = res + mean
-        std = nn.functional.softplus(std)
-        std = torch.clamp(std, min=self.min_std)
-        return Normal(mean, std)
 
-    def nll(self, prd_dist: Normal, trg: torch.Tensor) -> torch.Tensor:
-        return -prd_dist.log_prob(trg).mean()
+        std = nn.functional.softplus(std_raw)
+        std = torch.clamp(std, min=self.min_std)
+        return CNPPrediction(mean=mean, std=std, V=V)
+
+    def nll(self, prd: CNPPrediction, trg: torch.Tensor) -> torch.Tensor:
+        """Negative log-likelihood.
+
+        When V is present, uses the full NLL under N(mean, LLᵀ) where
+        L = diag(d) + VVᵀ. Otherwise falls back to diagonal NLL.
+        """
+        if prd.V is not None:
+            return lr_nll(trg, prd.mean, prd.std, prd.V)
+        return -prd.diagonal_dist.log_prob(trg).mean()
+
+    def _sample(self, prd: CNPPrediction) -> torch.Tensor:
+        """Sample from the predicted distribution.
+
+        When V is present, draws z ~ N(0,I) and computes x = Lz + mean
+        (i.e. unnormalize). Otherwise samples from the diagonal Normal.
+        """
+        if prd.V is not None:
+            z = torch.randn_like(prd.mean)
+            return lr_unnormalize(z, prd.mean, prd.std, prd.V)
+        return prd.diagonal_dist.sample()
 
     @torch.no_grad()
     def sample(self, ctx: ModelCtx, num_samples: int = 0, **kwargs) -> torch.Tensor:
@@ -69,15 +138,13 @@ class CNP(nn.Module):
         :return: Generated samples of shape
             (num_samples, out_channels, height, width).
         """
-        prd_dist = self.predict(ctx)
-        return prd_dist.sample()
+        return self._sample(self.predict(ctx))
 
     def sample_with_grad(self, ctx: ModelCtx) -> torch.Tensor:
-        prd_dist = self.predict(ctx)
-        return prd_dist.sample()
+        return self._sample(self.predict(ctx))
 
     def make_plot(self, ctx: ModelCtx) -> list[torch.Tensor]:
         pred = self.predict(ctx)
         masked_image = ctx.image_ctx[:, -3:, :, :]  # type: ignore
         mask = ctx.image_ctx[:, :1, :, :].repeat(1, 3, 1, 1)  # type: ignore
-        return [mask, masked_image, pred.mean, pred.stddev, pred.sample()]
+        return [mask, masked_image, pred.mean, pred.std, self._sample(pred)]

--- a/src/cdnp/model/low_rank_cov.py
+++ b/src/cdnp/model/low_rank_cov.py
@@ -1,0 +1,189 @@
+"""Low-rank normalization utilities.
+
+Defines a normalizing transform L = diag(d) + V Vᵀ that operates jointly
+across channels and spatial dimensions. Uses the Woodbury matrix identity
+for efficient inversion.
+"""
+
+import torch
+import torch.amp
+from torch import Tensor
+
+
+def normalize(
+    x: Tensor,
+    mean: Tensor,
+    d: Tensor,
+    V: Tensor,
+) -> Tensor:
+    """Normalize: z = L⁻¹(x - mean) where L = diag(d) + V Vᵀ.
+
+    Uses the Woodbury identity for efficient inversion:
+        L⁻¹ = D⁻¹ − D⁻¹V(I + VᵀD⁻¹V)⁻¹VᵀD⁻¹
+
+    Args:
+        x: Data to normalize, shape (B, C, H, W).
+        mean: Per-pixel mean, shape (B, C, H, W) or broadcastable.
+        d: Diagonal factor (positive), shape (B, C, H, W) or broadcastable.
+        V: Low-rank factors, shape (B, rank, C, H, W).
+
+    Returns:
+        Normalized data z, shape (B, C, H, W).
+    """
+    # Run in float32 — linalg.solve does not support float16.
+    input_dtype = x.dtype
+    with torch.amp.autocast("cuda", enabled=False):
+        x = x.float()
+        mean = mean.float()
+        d = d.float()
+        V = V.float()
+
+        B = x.shape[0]
+        rank = V.shape[1]
+        N = x[0].numel()  # C*H*W
+
+        # Flatten (C, H, W) -> (N,) where N = C*H*W
+        x_flat = (x - mean).reshape(B, N)  # (B, N)
+        d_flat = d.reshape(B, N)  # (B, N) or broadcastable
+        V_flat = V.reshape(B, rank, N)  # (B, rank, N)
+
+        # D⁻¹ x
+        d_inv = 1.0 / d_flat  # (B, N)
+        D_inv_x = d_inv * x_flat  # (B, N)
+
+        # D⁻¹ V  -> (B, N, rank)
+        D_inv_V = d_inv.unsqueeze(-1) * V_flat.permute(0, 2, 1)  # (B, N, rank)
+
+        # Inner matrix: I + Vᵀ D⁻¹ V  -> (B, rank, rank)
+        inner = torch.eye(rank, device=x.device).unsqueeze(0)
+        inner = inner + torch.bmm(V_flat, D_inv_V)  # (B, rank, rank)
+
+        # (I + Vᵀ D⁻¹ V)⁻¹ Vᵀ D⁻¹ x  -> (B, rank)
+        Vt_Dinv_x = torch.bmm(V_flat, D_inv_x.unsqueeze(-1)).squeeze(-1)  # (B, rank)
+        correction_coeff = torch.linalg.solve(inner, Vt_Dinv_x)  # (B, rank)
+
+        # D⁻¹ V @ correction_coeff  -> (B, N)
+        correction = torch.bmm(D_inv_V, correction_coeff.unsqueeze(-1)).squeeze(-1)
+
+        z_flat = D_inv_x - correction  # (B, N)
+        return z_flat.reshape_as(x).to(input_dtype)
+
+
+def log_det_L(
+    d: Tensor,
+    V: Tensor,
+) -> Tensor:
+    """Log-determinant of L = diag(d) + V Vᵀ via the matrix determinant lemma.
+
+    log det(L) = log det(diag(d)) + log det(I + Vᵀ D⁻¹ V)
+               = Σ log(dᵢ) + log det(I + Vᵀ D⁻¹ V)
+
+    The inner matrix is (rank × rank), so this is cheap.
+
+    Args:
+        d: Diagonal factor (positive), shape (B, C, H, W).
+        V: Low-rank factors, shape (B, rank, C, H, W).
+
+    Returns:
+        Log-determinant per sample, shape (B,).
+    """
+    # Run in float32 — slogdet does not support float16.
+    input_dtype = d.dtype
+    with torch.amp.autocast("cuda", enabled=False):
+        d = d.float()
+        V = V.float()
+
+        B = d.shape[0]
+        rank = V.shape[1]
+        N = d[0].numel()
+
+        d_flat = d.reshape(B, N)  # (B, N)
+        V_flat = V.reshape(B, rank, N)  # (B, rank, N)
+
+        # Σ log(dᵢ)
+        log_det_diag = d_flat.log().sum(dim=-1)  # (B,)
+
+        if rank == 0:
+            return log_det_diag.to(input_dtype)
+
+        # I + Vᵀ D⁻¹ V  -> (B, rank, rank)
+        d_inv = 1.0 / d_flat  # (B, N)
+        D_inv_V = d_inv.unsqueeze(-1) * V_flat.permute(0, 2, 1)  # (B, N, rank)
+        inner = torch.eye(rank, device=d.device).unsqueeze(0)
+        inner = inner + torch.bmm(V_flat, D_inv_V)  # (B, rank, rank)
+
+        # log det of (rank × rank) matrix
+        log_det_inner = torch.linalg.slogdet(inner).logabsdet  # (B,)
+
+        return (log_det_diag + log_det_inner).to(input_dtype)
+
+
+def nll(
+    x: Tensor,
+    mean: Tensor,
+    d: Tensor,
+    V: Tensor,
+) -> Tensor:
+    """Negative log-likelihood under N(mean, LLᵀ) where L = diag(d) + VVᵀ.
+
+    NLL = ½(‖z‖² + 2·log det(L) + N·log(2π))
+    where z = L⁻¹(x - mean).
+
+    Args:
+        x: Data, shape (B, C, H, W).
+        mean: Per-pixel mean, shape (B, C, H, W).
+        d: Diagonal factor (positive), shape (B, C, H, W).
+        V: Low-rank factors, shape (B, rank, C, H, W).
+
+    Returns:
+        Scalar mean NLL across batch and dimensions.
+    """
+    N = x[0].numel()
+
+    z = normalize(x, mean, d, V)
+    z_sq = (z * z).reshape(x.shape[0], -1).sum(dim=-1)  # (B,)
+    log_det = log_det_L(d, V)  # (B,)
+
+    # Per-sample NLL, then mean over batch
+    nll_per_sample = 0.5 * (z_sq + 2.0 * log_det + N * torch.log(torch.tensor(2.0 * torch.pi)))
+    # Normalize by N to match scale of diagonal NLL (which averages over dimensions)
+    return (nll_per_sample / N).mean()
+
+
+def unnormalize(
+    z: Tensor,
+    mean: Tensor,
+    d: Tensor,
+    V: Tensor,
+) -> Tensor:
+    """Unnormalize: x = L z + mean where L = diag(d) + V Vᵀ.
+
+    Direct computation (no inversion needed):
+        L z = d ⊙ z + V(Vᵀz)
+
+    Args:
+        z: Normalized data, shape (B, C, H, W).
+        mean: Per-pixel mean, shape (B, C, H, W) or broadcastable.
+        d: Diagonal factor (positive), shape (B, C, H, W) or broadcastable.
+        V: Low-rank factors, shape (B, rank, C, H, W).
+
+    Returns:
+        Unnormalized data x, shape (B, C, H, W).
+    """
+    B = z.shape[0]
+    rank = V.shape[1]
+    N = z[0].numel()  # C*H*W
+
+    z_flat = z.reshape(B, N)  # (B, N)
+    d_flat = d.reshape(B, N)  # (B, N) or broadcastable
+    V_flat = V.reshape(B, rank, N)  # (B, rank, N)
+
+    # d ⊙ z
+    dz = d_flat * z_flat  # (B, N)
+
+    # V(Vᵀz) = V @ (V @ z)
+    Vt_z = torch.bmm(V_flat, z_flat.unsqueeze(-1)).squeeze(-1)  # (B, rank)
+    VVt_z = torch.bmm(V_flat.permute(0, 2, 1), Vt_z.unsqueeze(-1)).squeeze(-1)  # (B, N)
+
+    x_flat = dz + VVt_z  # (B, N)
+    return x_flat.reshape_as(z) + mean

--- a/src/cdnp/model/warm_start_diffusion.py
+++ b/src/cdnp/model/warm_start_diffusion.py
@@ -5,10 +5,12 @@ import torch
 from torch import nn
 from torch.distributions import Normal
 
-from cdnp.model.cnp import CNP
+from cdnp.model.cnp import CNP, CNPPrediction
 from cdnp.model.ctx import ModelCtx
 from cdnp.model.ddpm import DDPM
 from cdnp.model.flow_matching.flow_matching import FlowMatching
+from cdnp.model.low_rank_cov import normalize as lr_normalize
+from cdnp.model.low_rank_cov import unnormalize as lr_unnormalize
 
 
 # TODO move CDNP to use this logic
@@ -27,6 +29,7 @@ class WarmStartDiffusion(nn.Module):
         end_to_end: bool = True,
         end_to_end_nll_weight: float = 0.01,
         norm_param_path: str | None = None,
+        correlation_rank: int = 0,
     ):
         super().__init__()
         if warm_start_model is None and norm_param_path is None:
@@ -47,10 +50,16 @@ class WarmStartDiffusion(nn.Module):
         self.feature_only_ablation = feature_only_ablation
         self.min_std = min_std
         self.nll_weight = end_to_end_nll_weight
+        self.correlation_rank = correlation_rank
 
         if norm_param_path is None:
             self.prd_dist = None
         else:
+            if correlation_rank > 0:
+                raise ValueError(
+                    "Low-rank correlation is only supported with a warm-start model, "
+                    "not with static norm_param_path."
+                )
             norm_params = np.load(norm_param_path)
             mean = torch.tensor(norm_params["mean"], device=device)
             std = torch.tensor(norm_params["std"], device=device)
@@ -78,30 +87,43 @@ class WarmStartDiffusion(nn.Module):
         if mean_only_ablation and feature_only_ablation:
             raise ValueError("Cannot use both mean-only and feature-only ablation.")
 
-    def forward(self, ctx: ModelCtx, trg: torch.Tensor) -> torch.Tensor:
+    def _predict(self, ctx: ModelCtx) -> CNPPrediction:
+        """Get the prediction (from warm-start model or static params)."""
         if self.prd_dist is None:
-            prd_dist = self.warm_start_model.predict(ctx)  # type: ignore
+            return self.warm_start_model.predict(ctx)  # type: ignore
         else:
-            prd_dist = self.prd_dist
-        mean = prd_dist.mean.detach()
-        std = prd_dist.stddev.detach()
+            # Static norm params: wrap in CNPPrediction (no V factors).
+            return CNPPrediction(
+                mean=self.prd_dist.mean,
+                std=self.prd_dist.stddev,
+                V=None,
+            )
 
-        std, warmth = self._get_warm_std(std)
+    def forward(self, ctx: ModelCtx, trg: torch.Tensor) -> torch.Tensor:
+        prd = self._predict(ctx)
+        mean = prd.mean.detach()
+        std = prd.std.detach()
+        V = prd.V.detach() if prd.V is not None else None
+
+        std, V, warmth = self._apply_warmth(std, V)
 
         if self.mean_only_ablation:
             std = torch.ones_like(std, device=self.device)
+            V = None
             warmth = None
 
         if self.feature_only_ablation:
             trg_n = trg
         else:
             # _n suffix = normalised space
-            trg_n = (trg - mean) / std
+            trg_n = self._normalize(trg, mean, std, V)
 
         gen_model_ctx = ModelCtx(
             image_ctx=self._build_image_ctx(ctx, mean, std, trg_n.shape[0]),
             warmth=warmth,
         )
+        # TODO: investigate passing V factors as additional context channels
+        # to the generative model.
 
         if self.loss_weighting:
             loss_weight = std
@@ -110,19 +132,54 @@ class WarmStartDiffusion(nn.Module):
 
         loss = self.generative_model(gen_model_ctx, trg_n, loss_weight=loss_weight)
         if self.end_to_end and self.warm_start_model is not None:
-            loss += self.nll_weight * self.warm_start_model.nll(prd_dist, trg)
+            loss += self.nll_weight * self.warm_start_model.nll(prd, trg)
 
         return loss
 
-    def _get_warm_std(
-        self, prd_std: torch.Tensor, warmth: Optional[torch.Tensor] = None
-    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+    def _normalize(
+        self,
+        x: torch.Tensor,
+        mean: torch.Tensor,
+        std: torch.Tensor,
+        V: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        """Normalize data using diagonal std and optional low-rank factors."""
+        if V is not None and self.correlation_rank > 0:
+            return lr_normalize(x, mean, std, V)
+        else:
+            return (x - mean) / std
+
+    def _unnormalize(
+        self,
+        z: torch.Tensor,
+        mean: torch.Tensor,
+        std: torch.Tensor,
+        V: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        """Unnormalize data using diagonal std and optional low-rank factors."""
+        if V is not None and self.correlation_rank > 0:
+            return lr_unnormalize(z, mean, std, V)
+        else:
+            return z * std + mean
+
+    def _apply_warmth(
+        self,
+        prd_std: torch.Tensor,
+        V: Optional[torch.Tensor],
+        warmth: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
         """
-        Get a warmth-scaled standard deviation.
+        Apply warmth scaling to std and V.
+
+        Warmth interpolates between the predicted normalisation and
+        the identity (standard normal prior):
+          d_warm = warmth * d + (1-warmth) * 1
+          V_warm = warmth * V  (vanishes at warmth=0)
         """
         prd_std = prd_std.clamp(min=self.min_std)
         if not self.scale_warmth:
-            return prd_std, None
+            return prd_std, V, None
+
         batch_size = prd_std.shape[0]
         base_std = torch.ones_like(prd_std, device=self.device)
         if warmth is None:
@@ -131,12 +188,15 @@ class WarmStartDiffusion(nn.Module):
                 * (self.max_warmth - self.min_warmth)
                 + self.min_warmth
             )
-        warmth = warmth[:, None, None, None]
+        warmth_expanded = warmth[:, None, None, None]
 
-        # prd_std = prd_std.clamp(min=1.0 - warmth)
+        scaled_std = warmth_expanded * prd_std + (1 - warmth_expanded) * base_std
 
-        scaled_std = warmth * prd_std + (1 - warmth) * base_std
-        return scaled_std, warmth.squeeze()
+        if V is not None:
+            # Scale V: vanishes at warmth=0 (standard normal prior).
+            V = warmth_expanded.unsqueeze(1) * V  # (B,1,1,1,1) * (B,rank,C,H,W)
+
+        return scaled_std, V, warmth.squeeze()
 
     def _build_image_ctx(
         self, ctx: ModelCtx, mean: torch.Tensor, std: torch.Tensor, batch_size: int
@@ -162,31 +222,30 @@ class WarmStartDiffusion(nn.Module):
         # For conditional generation, generate samples based on the context.
         if ctx.image_ctx is not None:
             num_samples = ctx.image_ctx.shape[0]
-        if self.prd_dist is None:
-            prd_dist = self.warm_start_model.predict(ctx)  # type: ignore
-            prd_dist = Normal(prd_dist.mean, prd_dist.stddev)
-        else:
-            prd_dist = self.prd_dist
+
+        prd = self._predict(ctx)
 
         initial_warmth = kwargs.get("warmth", self._get_sample_warmth(kwargs))
 
-        std = prd_dist.stddev
-        mean = prd_dist.mean
+        std = prd.std
+        mean = prd.mean
+        V = prd.V
+
         if self.scale_warmth:
             # During sampling, for now, we use a constant (full) warmth.
             # TODO: Experiment with different warmth schedules.
             warmth = torch.ones(num_samples, device=self.device) * initial_warmth
-            std, warmth = self._get_warm_std(std, warmth)
+            std, V, _warmth = self._apply_warmth(std, V, warmth)
         else:
-            warmth = None
+            std = std.clamp(min=self.min_std)
 
         if self.mean_only_ablation:
             std = torch.ones_like(std, device=self.device)
-            warmth = None
+            V = None
 
         gen_model_ctx = ModelCtx(
             image_ctx=self._build_image_ctx(ctx, mean, std, num_samples),
-            warmth=warmth,
+            warmth=_warmth if self.scale_warmth else None,
         )
 
         samples_n = self.generative_model.sample(gen_model_ctx, num_samples, **kwargs)
@@ -195,7 +254,7 @@ class WarmStartDiffusion(nn.Module):
             return samples_n
 
         # Go back to unnormalised space
-        samples = samples_n * std + prd_dist.mean
+        samples = self._unnormalize(samples_n, mean, std, V)
 
         return samples
 

--- a/src/config/cifar10_inpaint_cnp_correlated.yaml
+++ b/src/config/cifar10_inpaint_cnp_correlated.yaml
@@ -1,0 +1,21 @@
+defaults:
+  - base
+  - data: cifar10
+  - task: inpaint
+  - model: cnp
+  - model/backbone: small
+  - model_type: deterministic
+  - _self_
+
+data:
+  in_channels: 4 # masked RGB input + mask
+  preprocess_fn:
+    min_frac: 0.05
+    max_frac: 0.2
+
+model:
+  backbone:
+    out_channels: 18 # 2*C + C*rank = 2*3 + 3*4 = 18
+  min_std: 0.01
+  device: ${runtime.device}
+  correlation_rank: 4

--- a/src/config/model/cnp.yaml
+++ b/src/config/model/cnp.yaml
@@ -1,2 +1,3 @@
 _target_: cdnp.model.cnp.CNP
 device: ${runtime.device}
+correlation_rank: 0

--- a/src/config/model/warm_start_fm.yaml
+++ b/src/config/model/warm_start_fm.yaml
@@ -11,3 +11,4 @@ min_std: 0.01
 loss_weighting: false
 end_to_end: false
 end_to_end_nll_weight: 0.01
+correlation_rank: 0

--- a/src/config/model/warm_start_fm_no_attention.yaml
+++ b/src/config/model/warm_start_fm_no_attention.yaml
@@ -11,3 +11,4 @@ min_std: 0.01
 loss_weighting: false
 end_to_end: false
 end_to_end_nll_weight: 0.01
+correlation_rank: 0

--- a/tests/test_low_rank_cov.py
+++ b/tests/test_low_rank_cov.py
@@ -1,0 +1,267 @@
+"""Unit tests for low-rank covariance normalization."""
+
+import torch
+import pytest
+
+from cdnp.model.low_rank_cov import log_det_L, nll, normalize, unnormalize
+
+
+class TestLowRankNormalizer:
+    """Tests for the low-rank normalizer functions."""
+
+    @pytest.fixture
+    def shapes(self):
+        """Standard test shapes."""
+        return {"B": 2, "C": 3, "H": 8, "W": 10, "rank": 4}
+
+    @pytest.fixture
+    def data(self, shapes):
+        """Generate test data with standard shapes."""
+        B, C, H, W, rank = shapes["B"], shapes["C"], shapes["H"], shapes["W"], shapes["rank"]
+        torch.manual_seed(42)
+        return {
+            "x": torch.randn(B, C, H, W),
+            "mean": torch.randn(B, C, H, W),
+            "d": torch.rand(B, C, H, W) + 0.5,  # positive diagonal
+            "V": torch.randn(B, rank, C, H, W) * 0.1,  # small low-rank factors
+        }
+
+    def test_round_trip_identity(self, data):
+        """unnormalize(normalize(x)) should recover x."""
+        x, mean, d, V = data["x"], data["mean"], data["d"], data["V"]
+
+        z = normalize(x, mean, d, V)
+        x_reconstructed = unnormalize(z, mean, d, V)
+
+        torch.testing.assert_close(x_reconstructed, x, atol=1e-4, rtol=1e-4)
+
+    def test_round_trip_identity_large_v(self):
+        """Round-trip should work even with larger V factors."""
+        B, C, H, W, rank = 2, 2, 4, 6, 3
+        torch.manual_seed(123)
+        x = torch.randn(B, C, H, W)
+        mean = torch.randn(B, C, H, W)
+        d = torch.rand(B, C, H, W) + 1.0
+        V = torch.randn(B, rank, C, H, W) * 0.5
+
+        z = normalize(x, mean, d, V)
+        x_reconstructed = unnormalize(z, mean, d, V)
+
+        torch.testing.assert_close(x_reconstructed, x, atol=1e-4, rtol=1e-4)
+
+    def test_rank_zero_fallback_normalize(self):
+        """With V of rank 0 shape, normalize should behave like diagonal."""
+        B, C, H, W = 2, 3, 8, 10
+        torch.manual_seed(42)
+        x = torch.randn(B, C, H, W)
+        mean = torch.randn(B, C, H, W)
+        d = torch.rand(B, C, H, W) + 0.5
+        V = torch.zeros(B, 0, C, H, W)  # rank=0
+
+        # With V empty, should not crash but won't be identical to (x-mean)/d
+        # because V@V^T = 0, so L = diag(d), L^{-1} = diag(1/d)
+        # Actually it should work: I + V^T D^{-1} V = I (0x0), correction = 0
+        # Let's verify via unnormalize round-trip instead
+        z_diagonal = (x - mean) / d
+        z_low_rank = normalize(x, mean, d, V)
+        torch.testing.assert_close(z_low_rank, z_diagonal, atol=1e-5, rtol=1e-5)
+
+    def test_rank_zero_fallback_unnormalize(self):
+        """With V of rank 0, unnormalize should behave like diagonal."""
+        B, C, H, W = 2, 3, 8, 10
+        torch.manual_seed(42)
+        z = torch.randn(B, C, H, W)
+        mean = torch.randn(B, C, H, W)
+        d = torch.rand(B, C, H, W) + 0.5
+        V = torch.zeros(B, 0, C, H, W)
+
+        x_diagonal = z * d + mean
+        x_low_rank = unnormalize(z, mean, d, V)
+        torch.testing.assert_close(x_low_rank, x_diagonal, atol=1e-5, rtol=1e-5)
+
+    def test_output_shapes(self, data):
+        """Output shapes should match input shapes."""
+        x, mean, d, V = data["x"], data["mean"], data["d"], data["V"]
+
+        z = normalize(x, mean, d, V)
+        assert z.shape == x.shape
+
+        x_back = unnormalize(z, mean, d, V)
+        assert x_back.shape == x.shape
+
+    def test_normalize_gradient_flows(self, data):
+        """Gradients should flow through normalize."""
+        x = data["x"].requires_grad_(True)
+        mean = data["mean"]
+        d = data["d"].requires_grad_(True)
+        V = data["V"].requires_grad_(True)
+
+        z = normalize(x, mean, d, V)
+        loss = z.sum()
+        loss.backward()
+
+        assert x.grad is not None
+        assert d.grad is not None
+        assert V.grad is not None
+
+    def test_unnormalize_gradient_flows(self, data):
+        """Gradients should flow through unnormalize."""
+        z = data["x"].requires_grad_(True)
+        mean = data["mean"]
+        d = data["d"].requires_grad_(True)
+        V = data["V"].requires_grad_(True)
+
+        x = unnormalize(z, mean, d, V)
+        loss = x.sum()
+        loss.backward()
+
+        assert z.grad is not None
+        assert d.grad is not None
+        assert V.grad is not None
+
+    def test_manual_small_example(self):
+        """Verify against manual computation with a tiny example."""
+        # 1 batch, 1 channel, 1x2 spatial (N=2)
+        B, C, H, W, rank = 1, 1, 1, 2, 1
+        x = torch.tensor([[[[3.0, 5.0]]]])  # (1, 1, 1, 2)
+        mean = torch.tensor([[[[1.0, 2.0]]]])
+        d = torch.tensor([[[[2.0, 3.0]]]])
+        V = torch.tensor([[[[[0.5, 0.3]]]]]).reshape(B, rank, C, H, W)
+
+        # L = diag([2, 3]) + [0.5; 0.3] @ [0.5, 0.3]
+        # L = [[2.25, 0.15], [0.15, 3.09]]
+        # x - mean = [2, 3]
+        # L^{-1} (x-mean) via Woodbury:
+        # D^{-1} = diag([0.5, 1/3])
+        # D^{-1}(x-mean) = [1.0, 1.0]
+        # D^{-1}V = [0.25; 0.1]
+        # inner = 1 + V^T D^{-1} V = 1 + 0.5*0.25 + 0.3*0.1 = 1.155
+        # V^T D^{-1} (x-mean) = 0.5*1.0 + 0.3*1.0 = 0.8  (wait, V is (rank, N) = (1, 2))
+
+        # Let me compute manually:
+        centered = x - mean  # [2, 3]
+        d_flat = d.reshape(-1)  # [2, 3]
+        v_flat = V.reshape(1, -1)  # [0.5, 0.3]
+
+        d_inv = 1.0 / d_flat  # [0.5, 1/3]
+        d_inv_x = d_inv * centered.reshape(-1)  # [1.0, 1.0]
+        d_inv_v = d_inv * v_flat.reshape(-1)  # [0.25, 0.1]
+        inner = 1.0 + (v_flat.reshape(-1) * d_inv_v).sum()  # 1 + 0.125 + 0.0333 = 1.1583
+        vt_dinv_x = (v_flat.reshape(-1) * d_inv_x).sum()  # 0.5 + 0.3333 = 0.8333
+        correction = d_inv_v * (vt_dinv_x / inner)
+        expected_z = d_inv_x - correction
+
+        z = normalize(x, mean, d, V)
+        torch.testing.assert_close(z.reshape(-1), expected_z, atol=1e-5, rtol=1e-5)
+
+        # Round-trip
+        x_back = unnormalize(z, mean, d, V)
+        torch.testing.assert_close(x_back, x, atol=1e-5, rtol=1e-5)
+
+
+class TestLogDetL:
+    """Tests for log_det_L."""
+
+    def test_diagonal_only(self):
+        """With rank=0, log det(L) = Σ log(dᵢ)."""
+        B, C, H, W = 2, 3, 4, 5
+        torch.manual_seed(42)
+        d = torch.rand(B, C, H, W) + 0.5
+        V = torch.zeros(B, 0, C, H, W)
+
+        result = log_det_L(d, V)
+        expected = d.reshape(B, -1).log().sum(dim=-1)
+        torch.testing.assert_close(result, expected, atol=1e-5, rtol=1e-5)
+
+    def test_matches_dense_logdet(self):
+        """log det(L) should match torch.linalg.slogdet on the dense L matrix."""
+        B, C, H, W, rank = 1, 1, 2, 3, 2
+        N = C * H * W
+        torch.manual_seed(42)
+        d = torch.rand(B, C, H, W) + 0.5
+        V = torch.randn(B, rank, C, H, W) * 0.3
+
+        # Build dense L = diag(d) + V Vᵀ
+        d_flat = d.reshape(B, N)
+        V_flat = V.reshape(B, rank, N)
+        L_dense = torch.diag_embed(d_flat) + torch.bmm(
+            V_flat.permute(0, 2, 1), V_flat
+        )
+        expected = torch.linalg.slogdet(L_dense).logabsdet
+
+        result = log_det_L(d, V)
+        torch.testing.assert_close(result, expected, atol=1e-4, rtol=1e-4)
+
+    def test_gradient_flows(self):
+        """Gradients should flow through log_det_L."""
+        B, C, H, W, rank = 2, 2, 4, 4, 3
+        torch.manual_seed(42)
+        d = (torch.rand(B, C, H, W) + 0.5).requires_grad_(True)
+        V = (torch.randn(B, rank, C, H, W) * 0.1).requires_grad_(True)
+
+        result = log_det_L(d, V).sum()
+        result.backward()
+
+        assert d.grad is not None
+        assert V.grad is not None
+
+
+class TestNLL:
+    """Tests for the full NLL function."""
+
+    def test_diagonal_matches_normal_nll(self):
+        """With rank=0, NLL should match diagonal Normal NLL."""
+        B, C, H, W = 2, 3, 4, 5
+        torch.manual_seed(42)
+        x = torch.randn(B, C, H, W)
+        mean = torch.randn(B, C, H, W)
+        d = torch.rand(B, C, H, W) + 0.5
+        V = torch.zeros(B, 0, C, H, W)
+
+        result = nll(x, mean, d, V)
+
+        from torch.distributions import Normal
+        expected = -Normal(mean, d).log_prob(x).mean()
+        torch.testing.assert_close(result, expected, atol=1e-4, rtol=1e-4)
+
+    def test_matches_dense_mvn(self):
+        """NLL should match MultivariateNormal on dense covariance LLᵀ."""
+        B, C, H, W, rank = 1, 1, 2, 3, 2
+        N = C * H * W
+        torch.manual_seed(42)
+        x = torch.randn(B, C, H, W)
+        mean = torch.randn(B, C, H, W)
+        d = torch.rand(B, C, H, W) + 0.5
+        V = torch.randn(B, rank, C, H, W) * 0.3
+
+        result = nll(x, mean, d, V)
+
+        # Build dense L and covariance Σ = LLᵀ
+        d_flat = d.reshape(B, N)
+        V_flat = V.reshape(B, rank, N)
+        L_dense = torch.diag_embed(d_flat) + torch.bmm(
+            V_flat.permute(0, 2, 1), V_flat
+        )
+        cov = L_dense @ L_dense.transpose(-1, -2)
+
+        from torch.distributions import MultivariateNormal
+        mvn = MultivariateNormal(mean.reshape(B, N), covariance_matrix=cov)
+        expected = -mvn.log_prob(x.reshape(B, N)).mean() / N
+
+        torch.testing.assert_close(result, expected, atol=1e-4, rtol=1e-4)
+
+    def test_gradient_flows(self):
+        """Gradients should flow through nll to all parameters."""
+        B, C, H, W, rank = 2, 2, 4, 4, 3
+        torch.manual_seed(42)
+        x = torch.randn(B, C, H, W)
+        mean = torch.randn(B, C, H, W).requires_grad_(True)
+        d = (torch.rand(B, C, H, W) + 0.5).requires_grad_(True)
+        V = (torch.randn(B, rank, C, H, W) * 0.1).requires_grad_(True)
+
+        loss = nll(x, mean, d, V)
+        loss.backward()
+
+        assert mean.grad is not None
+        assert d.grad is not None
+        assert V.grad is not None


### PR DESCRIPTION
## Summary
- Add `LowRankNormalizer` utility (`low_rank_cov.py`) parameterizing `L = diag(d) + VVᵀ` with efficient Woodbury-based normalize/unnormalize, log-determinant via matrix determinant lemma, and full multivariate NLL — all O(N·rank + rank³)
- Extend `CNP` to predict low-rank factors `V` when `correlation_rank > 0`, trained by the full NLL under `N(mean, LLᵀ)` so V gets proper gradients
- Extend `WarmStartDiffusion` to use L for normalization with warmth scaling on V (V vanishes at warmth=0)
- Add `cifar10_inpaint_cnp_correlated.yaml` experiment config (rank=4)
- Add config defaults `correlation_rank: 0` (backward compatible)
- All linear algebra ops upcast to float32 for mixed-precision compatibility

## Test plan
- [x] 14 unit tests passing: round-trip identity, rank-0 fallback, gradient flow, manual verification, log-det vs dense, NLL vs `MultivariateNormal`, NLL vs diagonal `Normal` at rank-0
- [x] Training run with `correlation_rank=4` on cifar10 inpainting — loss decreases steadily
- [ ] Visual inspection of correlated samples from trained CNP

🤖 Generated with [Claude Code](https://claude.com/claude-code)